### PR TITLE
修复: c# 由于函数签名不一致导致的崩溃问题

### DIFF
--- a/aiui/c-sharp/aiui_csharp_demo/AIUISetting.cs
+++ b/aiui/c-sharp/aiui_csharp_demo/AIUISetting.cs
@@ -47,6 +47,11 @@ namespace aiui
             return aiui_set_data_log_dir(Marshal.StringToHGlobalAnsi(dir));
         }
 
+        public static void setSystemInfo(string key, string val)
+        {
+            aiui_set_system_info(Marshal.StringToHGlobalAnsi(key), Marshal.StringToHGlobalAnsi(val));
+        }
+
         public static bool setRawAudioDir(string dir)
         {
             return aiui_set_raw_audio_dir(Marshal.StringToHGlobalAnsi(dir));

--- a/aiui/c-sharp/aiui_csharp_demo/IAIUIAgent.cs
+++ b/aiui/c-sharp/aiui_csharp_demo/IAIUIAgent.cs
@@ -12,7 +12,7 @@ namespace aiui
         private AIUIMessageCallback messageCallback = null;
         private AIUIMessageCallback_ onEvent_ = null;
 
-        private void OnEvent(IntPtr ev_)
+        private void OnEvent(IntPtr ev_, IntPtr data)
         {
             messageCallback?.Invoke(new IAIUIEvent(ev_));
         }
@@ -21,7 +21,7 @@ namespace aiui
         {
             messageCallback = cb;
             onEvent_ = new AIUIMessageCallback_(OnEvent);
-            mAgent = aiui_agent_create(Marshal.StringToHGlobalAnsi(param), onEvent_);
+            mAgent = aiui_agent_create(Marshal.StringToHGlobalAnsi(param), onEvent_, IntPtr.Zero);
         }
 
         public static IAIUIAgent Create(string param, AIUIMessageCallback cb)
@@ -54,10 +54,10 @@ namespace aiui
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate void AIUIMessageCallback_(IntPtr ev);
+        private delegate void AIUIMessageCallback_(IntPtr ev, IntPtr data);
 
         [DllImport("aiui", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
-        private extern static IntPtr aiui_agent_create(IntPtr param, AIUIMessageCallback_ cb);
+        private extern static IntPtr aiui_agent_create(IntPtr param, AIUIMessageCallback_ cb, IntPtr data);
 
         [DllImport("aiui", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
         private extern static void aiui_agent_send_message(IntPtr agent, IntPtr msg);


### PR DESCRIPTION
1. 修复: c# 由于函数签名不一致导致的崩溃问题
2. 必传SN
3. 降低.net 版本